### PR TITLE
SIW.php : + HTML ⊃ Head ∋ Title

### DIFF
--- a/siw.php
+++ b/siw.php
@@ -1,6 +1,10 @@
-<?php
-echo "<pre>";
-
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ESR-SIW</title>
+  </head>
+  <body>
+    <pre><?php
 //Verifica se alguma página foi informada
 if ($_GET["artigo_titulo"]) {
 
@@ -37,17 +41,14 @@ if ($_GET["artigo_titulo"]) {
 }
 
 //Formulário de submissão do nome do artigo
-?><html>
-<head>
-	<title>ESR-SIW</title>
-</head>
-<body>
-<br>
-<form action="/alberobot/siw.php" method="get">
-  <input type="text" placeholder="Nome do artigo" name="artigo_titulo">
-  <input type="submit">
-</form>
-<br>
-<a href="https://wikitech.wikimedia.org/wiki/Portal:Toolforge"><img src="https://tools-static.wmflabs.org/toolforge/banners/Powered-by-Toolforge-button.png" alt="Powered by Wikimedia Toolforge"></a>
-</body>
+?>
+      <br>
+      <form action="/alberobot/siw.php" method="get">
+        <input type="text" placeholder="Nome do artigo" name="artigo_titulo">
+        <input type="submit">
+      </form>
+      <br>
+      <a href="https://wikitech.wikimedia.org/wiki/Portal:Toolforge"><img src="https://tools-static.wmflabs.org/toolforge/banners/Powered-by-Toolforge-button.png" alt="Powered by Wikimedia Toolforge"></a>
+    </pre>
+  </body>
 </html>

--- a/siw.php
+++ b/siw.php
@@ -37,10 +37,17 @@ if ($_GET["artigo_titulo"]) {
 }
 
 //Formulário de submissão do nome do artigo
-?><br>
+?><html>
+<head>
+	<title>ESR-SIW</title>
+</head>
+<body>
+<br>
 <form action="/alberobot/siw.php" method="get">
   <input type="text" placeholder="Nome do artigo" name="artigo_titulo">
   <input type="submit">
 </form>
 <br>
 <a href="https://wikitech.wikimedia.org/wiki/Portal:Toolforge"><img src="https://tools-static.wmflabs.org/toolforge/banners/Powered-by-Toolforge-button.png" alt="Powered by Wikimedia Toolforge"></a>
+</body>
+</html>


### PR DESCRIPTION
Estava deselegante as abas no navegador ficarem com o endereço da URL por extenso, ao invés de um título mais curto.