### PR TITLE
SIW.php : artigo não existe → mostrar só o erro

### DIFF
--- a/siw.php
+++ b/siw.php
@@ -60,13 +60,6 @@ function api_get($params) {
 //Verifica se alguma página foi informada
 if ($_GET["artigo_titulo"]) {
 
-	//Introdução da lista
-	echo 	"<p class='w3-center w3-wide'>EDITORES DO ARTIGO</p>
-			<h3 class='w3-center' style='hyphens: auto;'><b>".trim($_GET["artigo_titulo"])."</b></h3>
-			<small>Ao clicar, uma nova janela será aberta para o envio da mensagem. Em seguida, clique em \"Publicar alterações\", ou use o atalho ALT+SHIFT+S.</small>
-			<br><br>
-			<ul class='w3-ul w3-hoverable w3-border'>";
-
 	//Coleta nome dos usuários que editaram o artigo, excluindo os bots
 	$contributors_params = [
 		"action"          => "query",
@@ -80,9 +73,15 @@ if ($_GET["artigo_titulo"]) {
 
 	//Verifica se artigo não existe
 	if (isset($contributors['missing'])) {
-		echo "Artigo não existe!";
+		echo "<h3 class='w3-center' style='hyphens: auto;'><b>Artigo ".trim($_GET["artigo_titulo"])." não existe!</b></h3>";
 	} else {
-
+		//Introdução da lista
+		echo 	"<p class='w3-center w3-wide'>EDITORES DO ARTIGO</p>
+				<h3 class='w3-center' style='hyphens: auto;'><b>".trim($_GET["artigo_titulo"])."</b></h3>
+				<small>Ao clicar, uma nova janela será aberta para o envio da mensagem. Em seguida, clique em \"Publicar alterações\", ou use o atalho ALT+SHIFT+S.</small>
+				<br><br>
+				<ul class='w3-ul w3-hoverable w3-border'>";
+			
 		//Coloca nomes dos usuários na array
 		$contributors = $contributors['contributors'];
 


### PR DESCRIPTION
Caso o artigo não exista, é incorreto aparecer o título "EDITORES DO ARTIGO", e inadequado aparecer "Ao clicar, uma nova janela será aberta para o envio da mensagem. Em seguida, clique em "Publicar alterações", ou use o atalho ALT+SHIFT+S.".